### PR TITLE
Remove the "Hive" hashtag tab on Blog.D.Buzz and add "Events" and "FO…

### DIFF
--- a/src/components/common/Tabs/index.js
+++ b/src/components/common/Tabs/index.js
@@ -148,12 +148,15 @@ const Tabs = (props) => {
                     Latest
                 </div>
               )}
-             
+
               <div style={{fontFamily:'RobotoRegular'}} onClick={() => redirectPage('/news')} className={classNames(classes.cursorPointer,pathname === '/news'?classes.borderBottomSolid1p:'', classes.minWidthMaxContent, classes.paddingBottom16, classes.marginRight32, classes.displayBLock)}>
                     News
               </div>
-              <div style={{fontFamily:'RobotoRegular'}} onClick={() => redirectPage('/hive')} className={classNames(classes.cursorPointer,pathname === '/hive'?classes.borderBottomSolid1p:'', classes.minWidthMaxContent, classes.paddingBottom16, classes.marginRight32, classes.displayBLock)}>
-                    Hive
+              <div style={{fontFamily:'RobotoRegular'}} onClick={() => redirectPage('/events')} className={classNames(classes.cursorPointer,pathname === '/events'?classes.borderBottomSolid1p:'', classes.minWidthMaxContent, classes.paddingBottom16, classes.marginRight32, classes.displayBLock)}>
+                Event
+              </div>
+              <div style={{fontFamily:'RobotoRegular'}} onClick={() => redirectPage('/forsale')} className={classNames(classes.cursorPointer,pathname === '/forsale'?classes.borderBottomSolid1p:'', classes.minWidthMaxContent, classes.paddingBottom16, classes.marginRight32, classes.displayBLock)}>
+                FOR SALE
               </div>
             </div>
           </div>

--- a/src/components/common/Tabs/index.js
+++ b/src/components/common/Tabs/index.js
@@ -153,10 +153,10 @@ const Tabs = (props) => {
                     News
               </div>
               <div style={{fontFamily:'RobotoRegular'}} onClick={() => redirectPage('/events')} className={classNames(classes.cursorPointer,pathname === '/events'?classes.borderBottomSolid1p:'', classes.minWidthMaxContent, classes.paddingBottom16, classes.marginRight32, classes.displayBLock)}>
-                Event
+                Events
               </div>
               <div style={{fontFamily:'RobotoRegular'}} onClick={() => redirectPage('/forsale')} className={classNames(classes.cursorPointer,pathname === '/forsale'?classes.borderBottomSolid1p:'', classes.minWidthMaxContent, classes.paddingBottom16, classes.marginRight32, classes.displayBLock)}>
-                FOR SALE
+                For Sale
               </div>
             </div>
           </div>

--- a/src/components/pages/Events/index.js
+++ b/src/components/pages/Events/index.js
@@ -1,0 +1,123 @@
+import React, { useEffect, useCallback } from 'react'
+import { connect } from 'react-redux'
+import { bindActionCreators } from 'redux'
+import {
+  getEventsPostsRequest,
+  setEventsIsVisited,
+  setHomeIsVisited,
+  setTrendingIsVisited,
+  clearHomePosts,
+  clearTrendingPosts,
+  clearTagsPost,
+  setTagsIsVisited,
+  setPageFrom,
+  clearLastSearchTag,
+  clearSearchPosts,
+  clearAppendReply,
+  clearReplies,
+} from 'store/posts/actions'
+import {
+  setProfileIsVisited,
+  clearAccountBlog,
+  clearAccountReplies,
+} from 'store/profile/actions'
+import { pending } from 'redux-saga-thunk'
+import { anchorTop } from 'services/helper'
+import { InfiniteList, HelmetGenerator } from 'components'
+import { clearScrollIndex } from 'store/interfaces/actions'
+
+const Events = (props) => {
+  const {
+    getEventsPostsRequest,
+    setEventsIsVisited,
+    isVisited,
+    setHomeIsVisited,
+    setTrendingIsVisited,
+    clearHomePosts,
+    clearTrendingPosts,
+    setProfileIsVisited,
+    clearAccountBlog,
+    clearAccountReplies,
+    items,
+    last,
+    loading,
+    clearTagsPost,
+    setTagsIsVisited,
+    setPageFrom,
+    clearLastSearchTag,
+    clearSearchPosts,
+    clearAppendReply,
+    clearReplies,
+    clearScrollIndex,
+  } = props
+
+  useEffect(() => {
+    setPageFrom('hive')
+    if(!isVisited) {
+      anchorTop()
+      clearHomePosts()
+      clearScrollIndex()
+      clearTrendingPosts()
+      setEventsIsVisited()
+      getEventsPostsRequest()
+      setHomeIsVisited(false)
+      setTrendingIsVisited(false)
+    }
+    clearAppendReply()
+    clearSearchPosts()
+    clearLastSearchTag()
+    clearAccountBlog()
+    clearAccountReplies()
+    clearTagsPost()
+    clearReplies()
+    setTagsIsVisited(false)
+    setProfileIsVisited(false)
+    //eslint-disable-next-line
+  }, [])
+
+
+  const loadMorePosts =  useCallback(() => {
+    const { permlink, author } = last
+    getEventsPostsRequest(permlink, author)
+    // eslint-disable-next-line
+  }, [last])
+
+  return (
+    <React.Fragment>
+      <HelmetGenerator page='Events' />
+      <InfiniteList loading={loading} items={items} onScroll={loadMorePosts}/>
+    </React.Fragment>
+  )
+}
+
+const mapStateToProps = (state) => ({
+  loading: pending(state, 'GET_EVENTS_POSTS_REQUEST'),
+  items: state.posts.get('events'),
+  isVisited: state.posts.get('isEventsVisited'),
+  last: state.posts.get('lastEvents'),
+  mutelist: state.auth.get('mutelist'),
+})
+
+const mapDispatchToProps = (dispatch) => ({
+  ...bindActionCreators({
+    getEventsPostsRequest,
+    setEventsIsVisited,
+    setHomeIsVisited,
+    setTrendingIsVisited,
+    clearHomePosts,
+    clearTrendingPosts,
+    setProfileIsVisited,
+    clearAccountBlog,
+    clearAccountReplies,
+    clearTagsPost,
+    setTagsIsVisited,
+    setPageFrom,
+    clearLastSearchTag,
+    clearSearchPosts,
+    clearAppendReply,
+    clearReplies,
+    clearScrollIndex,
+  }, dispatch),
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(Events)

--- a/src/components/pages/Forsale/index.js
+++ b/src/components/pages/Forsale/index.js
@@ -1,0 +1,123 @@
+import React, { useEffect, useCallback } from 'react'
+import { connect } from 'react-redux'
+import { bindActionCreators } from 'redux'
+import {
+  getForsalePostsRequest,
+  setForsaleIsVisited,
+  setHomeIsVisited,
+  setTrendingIsVisited,
+  clearHomePosts,
+  clearTrendingPosts,
+  clearTagsPost,
+  setTagsIsVisited,
+  setPageFrom,
+  clearLastSearchTag,
+  clearSearchPosts,
+  clearAppendReply,
+  clearReplies,
+} from 'store/posts/actions'
+import {
+  setProfileIsVisited,
+  clearAccountBlog,
+  clearAccountReplies,
+} from 'store/profile/actions'
+import { pending } from 'redux-saga-thunk'
+import { anchorTop } from 'services/helper'
+import { InfiniteList, HelmetGenerator } from 'components'
+import { clearScrollIndex } from 'store/interfaces/actions'
+
+const Forsale = (props) => {
+  const {
+    getForsalePostsRequest,
+    setForsaleIsVisited,
+    isVisited,
+    setHomeIsVisited,
+    setTrendingIsVisited,
+    clearHomePosts,
+    clearTrendingPosts,
+    setProfileIsVisited,
+    clearAccountBlog,
+    clearAccountReplies,
+    items,
+    last,
+    loading,
+    clearTagsPost,
+    setTagsIsVisited,
+    setPageFrom,
+    clearLastSearchTag,
+    clearSearchPosts,
+    clearAppendReply,
+    clearReplies,
+    clearScrollIndex,
+  } = props
+
+  useEffect(() => {
+    setPageFrom('hive')
+    if(!isVisited) {
+      anchorTop()
+      clearHomePosts()
+      clearScrollIndex()
+      clearTrendingPosts()
+      setForsaleIsVisited()
+      getForsalePostsRequest()
+      setHomeIsVisited(false)
+      setTrendingIsVisited(false)
+    }
+    clearAppendReply()
+    clearSearchPosts()
+    clearLastSearchTag()
+    clearAccountBlog()
+    clearAccountReplies()
+    clearTagsPost()
+    clearReplies()
+    setTagsIsVisited(false)
+    setProfileIsVisited(false)
+    //eslint-disable-next-line
+  }, [])
+
+
+  const loadMorePosts =  useCallback(() => {
+    const { permlink, author } = last
+    getForsalePostsRequest(permlink, author)
+    // eslint-disable-next-line
+  }, [last])
+
+  return (
+    <React.Fragment>
+      <HelmetGenerator page='Forsale' />
+      <InfiniteList loading={loading} items={items} onScroll={loadMorePosts}/>
+    </React.Fragment>
+  )
+}
+
+const mapStateToProps = (state) => ({
+  loading: pending(state, 'GET_FORSALE_POSTS_REQUEST'),
+  items: state.posts.get('forsale'),
+  isVisited: state.posts.get('isForsaleVisited'),
+  last: state.posts.get('lastForsale'),
+  mutelist: state.auth.get('mutelist'),
+})
+
+const mapDispatchToProps = (dispatch) => ({
+  ...bindActionCreators({
+    getForsalePostsRequest,
+    setForsaleIsVisited,
+    setHomeIsVisited,
+    setTrendingIsVisited,
+    clearHomePosts,
+    clearTrendingPosts,
+    setProfileIsVisited,
+    clearAccountBlog,
+    clearAccountReplies,
+    clearTagsPost,
+    setTagsIsVisited,
+    setPageFrom,
+    clearLastSearchTag,
+    clearSearchPosts,
+    clearAppendReply,
+    clearReplies,
+    clearScrollIndex,
+  }, dispatch),
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(Forsale)

--- a/src/routes.js
+++ b/src/routes.js
@@ -5,6 +5,8 @@ const Home = React.lazy(() => import('./components/pages/Home'))
 const Trending = React.lazy(() => import('./components/pages/Trending'))
 const Latest = React.lazy(() => import('./components/pages/Latest'))
 const Hive = React.lazy(() => import('./components/pages/Hive'))
+const Events = React.lazy(() => import('./components/pages/Events'))
+const Forsale = React.lazy(() => import('./components/pages/Forsale'))
 const News = React.lazy(() => import('./components/pages/News'))
 const Content = React.lazy(() => import('./components/pages/Content'))
 const Profile = React.lazy(() => import('./components/pages/Profile'))
@@ -19,7 +21,7 @@ const SearchPosts = React.lazy(() => import('./components/sections/SearchPosts')
 const SearchPeople = React.lazy(() => import('./components/sections/SearchPeople'))
 // const CreateBuzzForm = React.lazy(() => import('./components/sections/CreateBuzzForm'))
 
-  
+
 const routes =  [
   {
     component: AppFrame,
@@ -48,6 +50,16 @@ const routes =  [
         path: '/latest',
         exact: true,
         component: Latest,
+      },
+      {
+        path: '/events',
+        exact: true,
+        component: Events,
+      },
+      {
+        path: '/forsale',
+        exact: true,
+        component: Forsale,
       },
       {
         path: '/hive',
@@ -134,5 +146,5 @@ const routes =  [
     ],
   },
 ]
- 
+
 export default routes

--- a/src/store/posts/actions.js
+++ b/src/store/posts/actions.js
@@ -123,6 +123,20 @@ export const setHiveIsVisited = (visited = true) => ({
   payload: visited,
 })
 
+export const SET_EVENTS_IS_VISITED = 'SET_EVENTS_IS_VISITED'
+
+export const setEventsIsVisited = (visited = true) => ({
+  type: SET_EVENTS_IS_VISITED,
+  payload: visited,
+})
+
+export const SET_FORSALE_IS_VISITED = 'SET_FORSALE_IS_VISITED'
+
+export const setForsaleIsVisited = (visited = true) => ({
+  type: SET_FORSALE_IS_VISITED,
+  payload: visited,
+})
+
 export const SET_TAGS_IS_VISITED = 'SET_TAGS_IS_VISITED'
 
 export const setTagsIsVisited = (visited = true) => ({
@@ -324,6 +338,68 @@ export const SET_HIVE_LAST_POST = 'SET_NEWS_LAST_POST'
 
 export const setHiveLastPost = (post) => ({
   type: SET_NEWS_LAST_POST,
+  payload: post,
+})
+
+export const GET_EVENTS_POSTS_REQUEST = 'GET_EVENTS_POSTS_REQUEST'
+export const GET_EVENTS_POSTS_SUCCESS = 'GET_EVENTS_POSTS_SUCCESS'
+export const GET_EVENTS_POSTS_FAILURE = 'GET_EVENTS_POSTS_FAILURE'
+
+export const getEventsPostsRequest = (start_permlink = '', start_author = '') => ({
+  type: GET_EVENTS_POSTS_REQUEST,
+  payload: { start_permlink, start_author },
+  meta: {
+    thunk: true,
+  },
+})
+
+export const getEventsPostsSuccess = (response, meta) => ({
+  type: GET_EVENTS_POSTS_SUCCESS,
+  payload: response,
+  meta,
+})
+
+export const getEventsPostsFailure = (error, meta) => ({
+  type: GET_EVENTS_POSTS_FAILURE,
+  payload: error,
+  meta,
+})
+
+export const SET_EVENTS_LAST_POST = 'SET_EVENTS_LAST_POST'
+
+export const setEventsLastPost = (post) => ({
+  type: SET_EVENTS_LAST_POST,
+  payload: post,
+})
+
+export const GET_FORSALE_POSTS_REQUEST = 'GET_FORSALE_POSTS_REQUEST'
+export const GET_FORSALE_POSTS_SUCCESS = 'GET_FORSALE_POSTS_SUCCESS'
+export const GET_FORSALE_POSTS_FAILURE = 'GET_FORSALE_POSTS_FAILURE'
+
+export const getForsalePostsRequest = (start_permlink = '', start_author = '') => ({
+  type: GET_FORSALE_POSTS_REQUEST,
+  payload: { start_permlink, start_author },
+  meta: {
+    thunk: true,
+  },
+})
+
+export const getForsalePostsSuccess = (response, meta) => ({
+  type: GET_FORSALE_POSTS_SUCCESS,
+  payload: response,
+  meta,
+})
+
+export const getForsalePostsFailure = (error, meta) => ({
+  type: GET_FORSALE_POSTS_FAILURE,
+  payload: error,
+  meta,
+})
+
+export const SET_FORSALE_LAST_POST = 'SET_FORSALE_LAST_POST'
+
+export const setForsaleLastPost = (post) => ({
+  type: SET_FORSALE_LAST_POST,
   payload: post,
 })
 

--- a/src/store/posts/reducers.js
+++ b/src/store/posts/reducers.js
@@ -4,6 +4,8 @@ import {
   GET_LATEST_POSTS_SUCCESS,
   GET_NEWS_POSTS_SUCCESS,
   GET_HIVE_POSTS_SUCCESS,
+  GET_EVENTS_POSTS_SUCCESS,
+  GET_FORSALE_POSTS_SUCCESS,
   GET_TRENDING_TAGS_SUCCESS,
   GET_TRENDING_POSTS_SUCCESS,
   SET_TRENDING_LAST_POST,
@@ -15,8 +17,12 @@ import {
   SET_LATEST_IS_VISITED,
   SET_NEWS_IS_VISITED,
   SET_HIVE_IS_VISITED,
+  SET_EVENTS_IS_VISITED,
+  SET_FORSALE_IS_VISITED,
   SET_LATEST_LAST_POST,
   SET_NEWS_LAST_POST,
+  SET_EVENTS_LAST_POST,
+  SET_FORSALE_LAST_POST,
   SET_TAGS_IS_VISITED,
   CLEAR_SEARCH_POSTS,
   CLEAR_LAST_SEARCH_TAG,
@@ -44,6 +50,8 @@ const defaultState = fromJS({
   latest: [],
   news: [],
   hive: [],
+  events: [],
+  forsale: [],
   content: {},
   search: {},
   searchTag: [],
@@ -55,6 +63,8 @@ const defaultState = fromJS({
   lastLatest: {},
   lastNews: {},
   lastHive: {},
+  lastEvents: {},
+  lastForsale: {},
   isHomeVisited: false,
   isTrendingVisited: false,
   isLatestVisited: false,
@@ -80,6 +90,10 @@ export const posts = (state = defaultState, { type, payload }) => {
     return state.set('lastLatest', payload)
   case SET_NEWS_LAST_POST:
     return state.set('lastNews', payload)
+  case SET_EVENTS_LAST_POST:
+    return state.set('lastEvents', payload)
+  case SET_FORSALE_LAST_POST:
+    return state.set('lastForsale', payload)
   case GET_HOME_POSTS_SUCCESS:
     return state.set('home', payload)
   case GET_LATEST_POSTS_SUCCESS:
@@ -88,6 +102,10 @@ export const posts = (state = defaultState, { type, payload }) => {
     return state.set('news', payload)
   case GET_HIVE_POSTS_SUCCESS:
     return state.set('hive', payload)
+  case GET_EVENTS_POSTS_SUCCESS:
+    return state.set('events', payload)
+  case GET_FORSALE_POSTS_SUCCESS:
+    return state.set('forsale', payload)
   case GET_TRENDING_TAGS_SUCCESS:
     return state.set('tags', payload)
   case GET_TRENDING_POSTS_SUCCESS:
@@ -124,7 +142,11 @@ export const posts = (state = defaultState, { type, payload }) => {
     return state.set('isNewsVisited', payload)
   case SET_HIVE_IS_VISITED:
     return state.set('isHiveVisited', payload)
-  case SET_TAGS_IS_VISITED: 
+  case SET_EVENTS_IS_VISITED:
+    return state.set('isEventsVisited', payload)
+  case SET_FORSALE_IS_VISITED:
+    return state.set('isForsaleVisited', payload)
+  case SET_TAGS_IS_VISITED:
     return state.set('isTagsVisited', payload)
   case CLEAR_APPEND_REPLY:
     return state.set('appendReply', {})

--- a/src/store/posts/sagas.js
+++ b/src/store/posts/sagas.js
@@ -33,6 +33,16 @@ import {
   getHivePostsFailure,
   setHiveLastPost,
 
+  GET_EVENTS_POSTS_REQUEST,
+  getEventsPostsSuccess,
+  getEventsPostsFailure,
+  setEventsLastPost,
+
+  GET_FORSALE_POSTS_REQUEST,
+  getForsalePostsSuccess,
+  getForsalePostsFailure,
+  setForsaleLastPost,
+
   setContentRedirect,
 
   GET_CONTENT_REQUEST,
@@ -142,7 +152,7 @@ function* getTrendingTagsRequests(meta) {
   try {
     let data = yield call(fetchTrendingTags)
     data = data.filter((tag) => !tag.name.includes('hive') && !tag.name.split('')[1].match(new RegExp('^\\d+$')))
-    
+
     yield put(getTrendingTagsSuccess(data, meta))
   } catch (error) {
     yield put(getTrendingTagsFailure(error, meta))
@@ -181,27 +191,27 @@ const invokeHideBuzzFilter = (items) => {
 
 function* getTrendingPostsRequest(payload, meta) {
   const { start_permlink, start_author } = payload
-  
+
   const params = { sort: 'trending', tag: '', start_permlink, start_author }
   const method = 'get_ranked_posts'
-  
+
   try {
     const old = yield select(state => state.posts.get('trending'))
     let data = yield call(callBridge, method, params)
-    
+
     data = [...old, ...data]
-    
+
     data = data.filter((obj, pos, arr) => {
       return arr.map(mapObj => mapObj['post_id']).indexOf(obj['post_id']) === pos
     })
-    
+
     yield put(setTrendingLastPost(data[data.length-1]))
     data = data.filter(item => invokeFilter(item))
-    
+
     const mutelist = yield select(state => state.auth.get('mutelist'))
     const opacityUsers = yield select(state => state.auth.get('opacityUsers'))
     data = invokeMuteFilter(data, mutelist, opacityUsers)
-    
+
     yield put(getTrendingPostsSuccess(data, meta))
   } catch(error) {
     console.log({error})
@@ -228,7 +238,7 @@ function* getHomePostsRequest(payload, meta) {
       data = data.filter((obj, pos, arr) => {
         return arr.map(mapObj => mapObj['post_id']).indexOf(obj['post_id']) === pos
       })
-      
+
       yield put(setHomeLastPost(data[data.length - 1]))
       const mutelist = yield select(state => state.auth.get('mutelist'))
       data = data.filter(item => invokeFilter(item))
@@ -358,6 +368,72 @@ function* getHivePostsRequest(payload, meta) {
   }
 }
 
+function* getEventsPostsRequest(payload, meta) {
+  const { start_permlink, start_author } = payload
+
+  const params = { sort: 'created', start_permlink, start_author }
+  const method = 'get_ranked_posts'
+
+  try {
+    const old = yield select(state => state.posts.get('events'))
+    let data = yield call(callBridge, method, params, true, 'events')
+
+    data = [...old, ...data]
+
+    data = data.filter((obj, pos, arr) => {
+      return arr.map(mapObj => mapObj['post_id']).indexOf(obj['post_id']) === pos
+    })
+
+    yield put(setEventsLastPost(data[data.length-1]))
+    data = data.filter(item => invokeFilter(item))
+
+    const mutelist = yield select(state => state.auth.get('mutelist'))
+    const opacityUsers = yield select(state => state.auth.get('opacityUsers'))
+    const patterns = yield call(getMutePattern)
+    data = invokeMuteFilter(data, mutelist, opacityUsers)
+
+    data = patternMute(patterns, data)
+
+
+    yield put(getEventsPostsSuccess(data, meta))
+  } catch(error) {
+    yield put(getEventsPostsFailure(error, meta))
+  }
+}
+
+function* getForsalePostsRequest(payload, meta) {
+  const { start_permlink, start_author } = payload
+
+  const params = { sort: 'created', start_permlink, start_author }
+  const method = 'get_ranked_posts'
+
+  try {
+    const old = yield select(state => state.posts.get('forsale'))
+    let data = yield call(callBridge, method, params, true, 'forsale')
+
+    data = [...old, ...data]
+
+    data = data.filter((obj, pos, arr) => {
+      return arr.map(mapObj => mapObj['post_id']).indexOf(obj['post_id']) === pos
+    })
+
+    yield put(setForsaleLastPost(data[data.length-1]))
+    data = data.filter(item => invokeFilter(item))
+
+    const mutelist = yield select(state => state.auth.get('mutelist'))
+    const opacityUsers = yield select(state => state.auth.get('opacityUsers'))
+    const patterns = yield call(getMutePattern)
+    data = invokeMuteFilter(data, mutelist, opacityUsers)
+
+    data = patternMute(patterns, data)
+
+
+    yield put(getForsalePostsSuccess(data, meta))
+  } catch(error) {
+    yield put(getForsalePostsFailure(error, meta))
+  }
+}
+
 function* getLinkMetaRequest(payload, meta) {
   try {
     const { url } = payload
@@ -438,7 +514,7 @@ function* fileUploadRequest(payload, meta) {
     const {file, progress} = payload
     console.log('im here', user)
     if (isAuthenticated) {
-      
+
       const result = yield call(uploadImage, file, progress)
 
       let images = []
@@ -941,6 +1017,14 @@ function* watchGetHivePostsRequest({payload, meta}) {
   yield call(getHivePostsRequest, payload, meta)
 }
 
+function* watchGetEventsPostsRequest({payload, meta}) {
+  yield call(getEventsPostsRequest, payload, meta)
+}
+
+function* watchGetForsalePostsRequest({payload, meta}) {
+  yield call(getForsalePostsRequest, payload, meta)
+}
+
 function* watchGetTrendingTagsRequest({ meta }) {
   yield call(getTrendingTagsRequests, meta)
 }
@@ -1001,6 +1085,8 @@ export default function* sagas() {
   yield takeEvery(GET_LATEST_POSTS_REQUEST, watchGetLatestPostsRequest)
   yield takeEvery(GET_NEWS_POSTS_REQUEST, watchGetNewsPostsRequest)
   yield takeEvery(GET_HIVE_POSTS_REQUEST, watchGetHivePostsRequest)
+  yield takeEvery(GET_EVENTS_POSTS_REQUEST, watchGetEventsPostsRequest)
+  yield takeEvery(GET_FORSALE_POSTS_REQUEST, watchGetForsalePostsRequest)
   yield takeEvery(GET_TRENDING_TAGS_REQUEST, watchGetTrendingTagsRequest)
   yield takeEvery(GET_TRENDING_POSTS_REQUEST, watchGetTrendingPostsRequest)
   yield takeEvery(GET_FOLLOW_DETAILS_REQUEST, watchGetFollowDetailsRequest)


### PR DESCRIPTION
The way it works is that the tabs at the top of desktop view in Blog.D.Buzz are basically just hashtag buttons.

The buttons are meant to act exactly like it would act if the the words were hashtags that were clicked on.

Keep in mind, hashtags should always be rendered at as all non-lower case at the blockchain level to prevent dividing hashtag feeds in two based on capitalization.

Anyhow, kindly remove the “Hive” tab and then add “Events” and “For Sale” (#ForSale). This means the top tab menu will read as follows.

Trending Following Latest News Events FOR SALE